### PR TITLE
chore: remove files

### DIFF
--- a/src/css/images/blue_arrow.svg:Zone.Identifier
+++ b/src/css/images/blue_arrow.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\zsamji\Downloads\OneDrive_1_9-26-2023.zip

--- a/src/css/images/green_tick.svg:Zone.Identifier
+++ b/src/css/images/green_tick.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\zsamji\Downloads\OneDrive_1_9-26-2023.zip

--- a/src/css/images/img_1.svg:Zone.Identifier
+++ b/src/css/images/img_1.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\zsamji\Downloads\OneDrive_1_9-26-2023.zip

--- a/src/css/images/img_2.svg:Zone.Identifier
+++ b/src/css/images/img_2.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\zsamji\Downloads\OneDrive_1_9-26-2023.zip

--- a/src/css/images/img_3.svg:Zone.Identifier
+++ b/src/css/images/img_3.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\zsamji\Downloads\OneDrive_1_9-26-2023.zip

--- a/src/css/images/img_4.svg:Zone.Identifier
+++ b/src/css/images/img_4.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\zsamji\Downloads\OneDrive_1_9-26-2023.zip

--- a/src/css/images/red_cross.svg:Zone.Identifier
+++ b/src/css/images/red_cross.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\zsamji\Downloads\OneDrive_1_9-26-2023.zip

--- a/src/css/images/yellow_tick.png:Zone.Identifier
+++ b/src/css/images/yellow_tick.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-LastWriterPackageFamilyName=Microsoft.ScreenSketch_8wekyb3d8bbwe
-ZoneId=3

--- a/src/css/images/yellow_tick.svg:Zone.Identifier
+++ b/src/css/images/yellow_tick.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\zsamji\Downloads\OneDrive_1_9-26-2023.zip


### PR DESCRIPTION
remove zone identifier files. Windows can add these unnecessary files when moving downloads into WSL